### PR TITLE
Fix current / native resolution parsing, and add tests with mocha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function (src) {
     var query = {};
     var last = null;
     var index = 0;
-    
+
     lines.forEach(function (line) {
         var m;
         if (m = re.connected.exec(line)) {
@@ -39,9 +39,9 @@ module.exports = function (src) {
                 rate: parseFloat(m[3])
             };
             query[last].modes.push(r);
-            
-            if (m[4] === '+') query[last]['native'] = r;
-            if (m[5] === '*') query[last].current = r;
+
+            if (m[4] === '+' || m[5] === '+') query[last]['native'] = r;
+            if (m[4] === '*' || m[5] === '*') query[last].current = r;
         }
         else {
             last = null;

--- a/package.json
+++ b/package.json
@@ -14,10 +14,17 @@
     "linux",
     "x11"
   ],
+  "scripts": {
+    "test": "mocha"
+  },
   "author": {
     "name": "James Halliday",
     "email": "mail@substack.net",
     "url": "http://substack.net"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "expect": "^1.20.2",
+    "mocha": "^3.2.0"
+  }
 }

--- a/test/fixtures/input1.txt
+++ b/test/fixtures/input1.txt
@@ -1,0 +1,21 @@
+Screen 0: minimum 8 x 8, current 1920 x 1080, maximum 32767 x 32767
+DP1 disconnected (normal left inverted right x axis y axis)
+HDMI1 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 531mm x 299mm
+   1920x1080     60.00*+  50.00    59.94
+   1920x1080i    60.00    50.00    59.94
+   1680x1050     59.88
+   1440x900      59.90
+   1280x960      60.00
+   1366x768      59.79    60.00
+   1360x768      60.02
+   1280x800      59.91
+   1280x768      59.87
+   1280x720      60.00    50.00    59.94
+   1024x768      60.00
+   800x600       60.32    56.25
+   720x576       50.00
+   720x576i      50.00
+   720x480       60.00    59.94
+   640x480       60.00    59.94
+HDMI2 disconnected (normal left inverted right x axis y axis)
+VIRTUAL1 disconnected (normal left inverted right x axis y axis)

--- a/test/fixtures/input2.txt
+++ b/test/fixtures/input2.txt
@@ -1,0 +1,21 @@
+Screen 0: minimum 8 x 8, current 1920 x 1080, maximum 32767 x 32767
+DP1 disconnected (normal left inverted right x axis y axis)
+HDMI1 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 531mm x 299mm
+   1920x1080     60.00+*  50.00    59.94
+   1920x1080i    60.00    50.00    59.94
+   1680x1050     59.88
+   1440x900      59.90
+   1280x960      60.00
+   1366x768      59.79    60.00
+   1360x768      60.02
+   1280x800      59.91
+   1280x768      59.87
+   1280x720      60.00    50.00    59.94
+   1024x768      60.00
+   800x600       60.32    56.25
+   720x576       50.00
+   720x576i      50.00
+   720x480       60.00    59.94
+   640x480       60.00    59.94
+HDMI2 disconnected (normal left inverted right x axis y axis)
+VIRTUAL1 disconnected (normal left inverted right x axis y axis)

--- a/test/fixtures/input3.txt
+++ b/test/fixtures/input3.txt
@@ -1,0 +1,21 @@
+Screen 0: minimum 8 x 8, current 1280 x 800, maximum 32767 x 32767
+DP1 disconnected (normal left inverted right x axis y axis)
+HDMI1 connected primary 1280x800+0+0 (normal left inverted right x axis y axis) 531mm x 299mm
+   1920x1080     60.00 +  50.00    59.94
+   1920x1080i    60.00    50.00    59.94
+   1680x1050     59.88
+   1440x900      59.90
+   1280x960      60.00
+   1366x768      59.79    60.00
+   1360x768      60.02
+   1280x800      59.91*
+   1280x768      59.87
+   1280x720      60.00    50.00    59.94
+   1024x768      60.00
+   800x600       60.32    56.25
+   720x576       50.00
+   720x576i      50.00
+   720x480       60.00    59.94
+   640x480       60.00    59.94
+HDMI2 disconnected (normal left inverted right x axis y axis)
+VIRTUAL1 disconnected (normal left inverted right x axis y axis)

--- a/test/fixtures/output1.json
+++ b/test/fixtures/output1.json
@@ -1,0 +1,113 @@
+{
+  "DP1": {
+    "connected": false,
+    "index": 0,
+    "modes": []
+  },
+  "HDMI1": {
+    "connected": true,
+    "current": {
+      "height": "1080",
+      "rate": 60,
+      "width": "1920"
+    },
+    "index": 1,
+    "modes": [
+      {
+        "height": "1080",
+        "rate": 60,
+        "width": "1920"
+      },
+      {
+        "height": "1080i",
+        "rate": 60,
+        "width": "1920"
+      },
+      {
+        "height": "1050",
+        "rate": 59.88,
+        "width": "1680"
+      },
+      {
+        "height": "900",
+        "rate": 59.9,
+        "width": "1440"
+      },
+      {
+        "height": "960",
+        "rate": 60,
+        "width": "1280"
+      },
+      {
+        "height": "768",
+        "rate": 59.79,
+        "width": "1366"
+      },
+      {
+        "height": "768",
+        "rate": 60.02,
+        "width": "1360"
+      },
+      {
+        "height": "800",
+        "rate": 59.91,
+        "width": "1280"
+      },
+      {
+        "height": "768",
+        "rate": 59.87,
+        "width": "1280"
+      },
+      {
+        "height": "720",
+        "rate": 60,
+        "width": "1280"
+      },
+      {
+        "height": "768",
+        "rate": 60,
+        "width": "1024"
+      },
+      {
+        "height": "600",
+        "rate": 60.32,
+        "width": "800"
+      },
+      {
+        "height": "576",
+        "rate": 50,
+        "width": "720"
+      },
+      {
+        "height": "576i",
+        "rate": 50,
+        "width": "720"
+      },
+      {
+        "height": "480",
+        "rate": 60,
+        "width": "720"
+      },
+      {
+        "height": "480",
+        "rate": 60,
+        "width": "640"
+      }
+    ],
+    "native": {
+      "height": "1080",
+      "rate": 60,
+      "width": "1920"
+    }
+  },
+  "HDMI2": {
+    "connected": false,
+    "index": 2,
+    "modes": []
+  },
+  "VIRTUAL1": {
+    "connected": false,
+    "index": 3,
+    "modes": []
+  }
+}

--- a/test/fixtures/output3.json
+++ b/test/fixtures/output3.json
@@ -1,0 +1,113 @@
+{
+  "DP1": {
+    "connected": false,
+    "index": 0,
+    "modes": []
+  },
+  "HDMI1": {
+    "connected": true,
+    "current": {
+      "height": "800",
+      "rate": 59.91,
+      "width": "1280"
+    },
+    "index": 1,
+    "modes": [
+      {
+        "height": "1080",
+        "rate": 60,
+        "width": "1920"
+      },
+      {
+        "height": "1080i",
+        "rate": 60,
+        "width": "1920"
+      },
+      {
+        "height": "1050",
+        "rate": 59.88,
+        "width": "1680"
+      },
+      {
+        "height": "900",
+        "rate": 59.9,
+        "width": "1440"
+      },
+      {
+        "height": "960",
+        "rate": 60,
+        "width": "1280"
+      },
+      {
+        "height": "768",
+        "rate": 59.79,
+        "width": "1366"
+      },
+      {
+        "height": "768",
+        "rate": 60.02,
+        "width": "1360"
+      },
+      {
+        "height": "800",
+        "rate": 59.91,
+        "width": "1280"
+      },
+      {
+        "height": "768",
+        "rate": 59.87,
+        "width": "1280"
+      },
+      {
+        "height": "720",
+        "rate": 60,
+        "width": "1280"
+      },
+      {
+        "height": "768",
+        "rate": 60,
+        "width": "1024"
+      },
+      {
+        "height": "600",
+        "rate": 60.32,
+        "width": "800"
+      },
+      {
+        "height": "576",
+        "rate": 50,
+        "width": "720"
+      },
+      {
+        "height": "576i",
+        "rate": 50,
+        "width": "720"
+      },
+      {
+        "height": "480",
+        "rate": 60,
+        "width": "720"
+      },
+      {
+        "height": "480",
+        "rate": 60,
+        "width": "640"
+      }
+    ],
+    "native": {
+      "height": "1080",
+      "rate": 60,
+      "width": "1920"
+    }
+  },
+  "HDMI2": {
+    "connected": false,
+    "index": 2,
+    "modes": []
+  },
+  "VIRTUAL1": {
+    "connected": false,
+    "index": 3,
+    "modes": []
+  }
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const expect = require('expect');
+const parser = require('./../index.js');
+
+describe('parser', () => {
+  // Fetch fixtures
+  const buffer1 = fs.readFileSync(`${__dirname}/fixtures/input1.txt`);
+  const buffer2 = fs.readFileSync(`${__dirname}/fixtures/input1.txt`);
+  const buffer3 = fs.readFileSync(`${__dirname}/fixtures/input3.txt`);
+  const expected1 = JSON.parse(fs.readFileSync(`${__dirname}/fixtures/output1.json`).toString());
+  const expected3 = JSON.parse(fs.readFileSync(`${__dirname}/fixtures/output3.json`).toString());
+
+  it('should throw if no string is passed', () => {
+    let value;
+    try {
+      value = parser(undefined);
+    }catch (err) {
+      expect(err).toBeA(Error);
+      expect(value).toNotExist();
+    }
+  });
+
+  it('should throw if buffer is passed', () => {
+    let value;
+    try {
+      value = parser(buffer1);
+    }catch (err) {
+      expect(err).toBeA(Error);
+      expect(value).toNotExist();
+    }
+  });
+
+  it('should accept a string as argument', () => {
+    let value;
+    try {
+      value = parser(buffer1.toString());
+    }catch (err) {
+      expect(err).toBeA(Error);
+      expect(value).toNotExist();
+    }
+  });
+
+  it('should properly parse the file input1.txt', () => {
+    const value = parser(buffer1.toString());
+    expect(value).toEqual(expected1);
+  });
+
+  it('should properly parse the file input2.txt', () => {
+    const value = parser(buffer2.toString());
+    expect(value).toEqual(expected1);
+  });
+
+  it('should properly parse the file input3.txt', () => {
+    const value = parser(buffer3.toString());
+    expect(value).toEqual(expected3);
+  });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--ui bdd
+--recursive


### PR DESCRIPTION
This PR fix a parse error on some xrandr outputs, where * and + are inverted.  
It also includes some tests to check some cases.